### PR TITLE
Fix key error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 *.db
 xmltv.xml
 xmltv.xml.gz
+.project
+.pydevproject
+.settings/org.eclipse.core.resources.prefs

--- a/libschedulesdirect/common.py
+++ b/libschedulesdirect/common.py
@@ -840,11 +840,10 @@ class SeasonEpisode(object):
         """
         season_episode = cls()
 
-        season_episode.season = dct.pop("season")
-
-        season_episode.episode = dct.pop("episode")
-
-        if len(dct) != 0:
+        if len(dct) != 0 and "season" in dct:
+            season_episode.season = dct.pop("season")
+            season_episode.episode = dct.pop("episode")
+        else:
             logging.warn("Key(s) not processed for SeasonEpisode: %s", ", ".join(dct.keys()))
 
         return season_episode


### PR DESCRIPTION
I found the error below when recreating my xmltv DB, so I've added some code to check for valid 'season' keys in the dictionary.  This isn't widely tested so please do sanity check it before merging!

The error occurs when the GraceNote collection includes a dictionary with 'totalSeasons: x, totalEpisodes: y' and no season/episode information. Not sure why this creeps in here, maybe the JSON has changed?  I'm using the UK database and the program that causes the error appears to be 'Program: SH013026900000 'Antiques Road Trip''

I used Eclipse to debug so I've also added the pydev exclusions to .gitignore - there's no need to keep these changes if you feel they're unnecessary.

2016-05-22 09:53:13,634 root                                WARNING  Key(s) not processed for Program: awards
Traceback (most recent call last):
  File "./sd2xmltv.py", line 362, in <module>
    main()
  File "./sd2xmltv.py", line 358, in main
    app.process()
  File "./sd2xmltv.py", line 113, in process
    program_lookup = self._sd.get_cached_programs(schedule_list.get_program_ids())
  File "/home/hts/sd2xmltv/libschedulesdirect/schedulesdirect.py", line 177, in get_cached_programs
    return {program.program_id: program for program in self._cache.get_programs(program_ids)}
  File "/home/hts/sd2xmltv/libschedulesdirect/schedulesdirect.py", line 177, in <dictcomp>
    return {program.program_id: program for program in self._cache.get_programs(program_ids)}
  File "/home/hts/sd2xmltv/libschedulesdirect/cache.py", line 130, in get_programs
    yield json.loads(item["program_json"], object_hook=Program.from_dict)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return cls(encoding=encoding, **kw).decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 381, in raw_decode
    obj, end = self.scan_once(s, idx)
  File "/home/hts/sd2xmltv/libschedulesdirect/common.py", line 1579, in from_dict
    program.metadata = ProgramMetadata.from_iterable(dct.pop("metadata"))
  File "/home/hts/sd2xmltv/libschedulesdirect/common.py", line 871, in from_iterable
    program_metadata.season_episode = SeasonEpisode.from_dict(item.pop("Gracenote"))
  File "/home/hts/sd2xmltv/libschedulesdirect/common.py", line 843, in from_dict
    season_episode.season = dct.pop("season")
