### PR TITLE
Crash when attempting to save lineups to filter config:

### DIFF
--- a/utils/channelfilters.py
+++ b/utils/channelfilters.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 import ConfigParser
-import codecs
+import io
 from libhdhomerun.client import HDHomeRunClient
 import os.path
 
@@ -71,7 +71,7 @@ class FileChannelFilter(object):
 
     def _load_config(self, config_path):
         if os.path.isfile(config_path):
-            with codecs.open(config_path, "rb", encoding='utf-8') as fp:
+            with io.open(config_path, 'r', encoding='utf-8') as fp:
                 self._config.readfp(fp)
 
         self._dirty = False
@@ -90,7 +90,6 @@ class FileChannelFilter(object):
             fp.write("; Note: New channels are not automatically moved from the [<headend>-new] section.\n")
             fp.write("; Cut and paste newly found channels under [<headend>-include] or [<headend>-exclude].\n")
             fp.write("\n")
-            dir(self._config)
             self._config.write(fp)
 
         self._dirty = False

--- a/utils/channelfilters.py
+++ b/utils/channelfilters.py
@@ -80,7 +80,7 @@ class FileChannelFilter(object):
         if not self._dirty and not force_save:
             return
 
-        with open(config_path, "wb") as fp:
+        with io.open(config_path, "wb") as fp:
             fp.write("; sd2xmltv channel filter\n")
             fp.write("; \n")
             fp.write("; Move channels to include under [<headend>-include].\n")

--- a/utils/channelfilters.py
+++ b/utils/channelfilters.py
@@ -57,7 +57,7 @@ class FileChannelFilter(object):
 
             for channel in lineup_map.channels:
                 channel_option = channel.channel + u"_" + channel.station.station_id
-                channel_option_value = channel.station.name
+                channel_option_value = channel.station.name.encode('ascii','replace')
 
                 if not self._config.has_option(config_section_new, channel_option) and \
                         not self._config.has_option(config_section_include, channel_option) and \
@@ -89,6 +89,7 @@ class FileChannelFilter(object):
             fp.write("; Note: New channels are not automatically moved from the [<headend>-new] section.\n")
             fp.write("; Cut and paste newly found channels under [<headend>-include] or [<headend>-exclude].\n")
             fp.write("\n")
+            dir(self._config)
             self._config.write(fp)
 
         self._dirty = False

--- a/utils/channelfilters.py
+++ b/utils/channelfilters.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import ConfigParser
+import codecs
 from libhdhomerun.client import HDHomeRunClient
 import os.path
 
@@ -57,7 +58,7 @@ class FileChannelFilter(object):
 
             for channel in lineup_map.channels:
                 channel_option = channel.channel + u"_" + channel.station.station_id
-                channel_option_value = channel.station.name.encode('ascii','replace')
+                channel_option_value = channel.station.name.encode('utf-8')
 
                 if not self._config.has_option(config_section_new, channel_option) and \
                         not self._config.has_option(config_section_include, channel_option) and \
@@ -70,7 +71,7 @@ class FileChannelFilter(object):
 
     def _load_config(self, config_path):
         if os.path.isfile(config_path):
-            with open(config_path, "rb") as fp:
+            with codecs.open(config_path, "rb", encoding='utf-8') as fp:
                 self._config.readfp(fp)
 
         self._dirty = False


### PR DESCRIPTION
If lineup data contains non-ASCII characters, ConfigParser (python 2.7)
crashed during .write with error such as
UnicodeEncodeError: 'ascii' codec can't encode character

Added force encoding of the value string to ascii with replace for unicode
for now to workaround the error for now.